### PR TITLE
Fix bounds check in Map::getTile and return type in generate_uniform_int

### DIFF
--- a/src/include/RandomEngine.h
+++ b/src/include/RandomEngine.h
@@ -25,7 +25,7 @@ public:
 
 	float generate_uniform_float(float min = 0.0, float max = 1.0);
 
-	float generate_uniform_int(int min, int max);
+	int generate_uniform_int(int min, int max);
 
 	template<typename Enum>
 	Enum generateRandomEnum(int count);

--- a/src/services/Map.cpp
+++ b/src/services/Map.cpp
@@ -3,7 +3,7 @@
 
 Tile Map::getTile(uint32_t x, uint32_t y) {
     
-    if(!(x > rows) || !(y > columns))
+    if(x < rows && y < columns)
         return tiles[x][y];
 }
 

--- a/src/services/RandomEngine.cpp
+++ b/src/services/RandomEngine.cpp
@@ -5,7 +5,7 @@ float RandomEngine::generate_uniform_float(float min, float max) {
 	return dist(rng);
 }
 
-float RandomEngine::generate_uniform_int(int min, int max) {
+int RandomEngine::generate_uniform_int(int min, int max) {
 	std::uniform_int_distribution<int> dist(min, max);
 	return dist(rng);
 }


### PR DESCRIPTION
## Summary

- **Map::getTile()** had an inverted bounds check using `||` instead of `&&`, which could allow out-of-bounds array access. Fixed to `x < rows && y < columns`.
- **RandomEngine::generate_uniform_int()** was declared and defined as returning `float` instead of `int`, causing implicit narrowing on every call. Fixed return type in both header and implementation.